### PR TITLE
Removed catchup by default on our jobs. 

### DIFF
--- a/airflow_dags/dag.py
+++ b/airflow_dags/dag.py
@@ -18,6 +18,7 @@ def get_default_args_helper(start_date: datetime):
             'email': ['airflow@liquidata.co'],
             'email_on_failure': False,
             'email_on_retry': False,
+            'catchup': False,
             'retry_delay': timedelta(minutes=5)}
 
 


### PR DESCRIPTION
This means if we miss scheduled runs, airflow will not try to run all the missed runs when it restarts, only the last missed run.

https://airflow.apache.org/scheduler.html