### PR TITLE
Added a -L to the curl command because Princeton moved the WordNet li…

### DIFF
--- a/airflow_dags/word_net/import_from_source.pl
+++ b/airflow_dags/word_net/import_from_source.pl
@@ -293,7 +293,7 @@ sub download_and_unpack {
     my $current_md5 = shift;
 
     chdir($tmpdir);
-    run_command("curl -O $url", "Could not download $url");
+    run_command("curl -L -O $url", "Could not download $url");
     
     my $file = `ls -1 .`;
     chomp($file);


### PR DESCRIPTION
…nk we were using

```Timothys-MacBook-Pro:word_net timsehn$ airflow test word_net import-data 2019-11-18
[2019-11-18 11:04:52,174] {__init__.py:51} INFO - Using executor SequentialExecutor
[2019-11-18 11:04:52,426] {dagbag.py:90} INFO - Filling up the DagBag from /Users/timsehn/liquidata/git/liquidata-etl-jobs/airflow_dags
[2019-11-18 11:04:53,190] {taskinstance.py:620} INFO - Dependencies all met for <TaskInstance: word_net.import-data 2019-11-18T00:00:00+00:00 [None]>
[2019-11-18 11:04:53,197] {taskinstance.py:620} INFO - Dependencies all met for <TaskInstance: word_net.import-data 2019-11-18T00:00:00+00:00 [None]>
[2019-11-18 11:04:53,197] {taskinstance.py:838} INFO - 
--------------------------------------------------------------------------------
[2019-11-18 11:04:53,197] {taskinstance.py:839} INFO - Starting attempt 1 of 1
[2019-11-18 11:04:53,197] {taskinstance.py:840} INFO - 
--------------------------------------------------------------------------------
[2019-11-18 11:04:53,198] {taskinstance.py:859} INFO - Executing <Task(BashOperator): import-data> on 2019-11-18T00:00:00+00:00
[2019-11-18 11:04:53,213] {bash_operator.py:81} INFO - Tmp dir root location: 
 /var/folders/t7/90tpn01n59j1mqt6xnvyv9m80000gn/T
[2019-11-18 11:04:53,214] {bash_operator.py:91} INFO - Exporting the following env vars:
AIRFLOW_CTX_DAG_ID=word_net
AIRFLOW_CTX_TASK_ID=import-data
AIRFLOW_CTX_EXECUTION_DATE=2019-11-18T00:00:00+00:00
[2019-11-18 11:04:53,214] {bash_operator.py:105} INFO - Temporary script location: /var/folders/t7/90tpn01n59j1mqt6xnvyv9m80000gn/T/airflowtmpkguox3oa/import-datau04lwg9i
[2019-11-18 11:04:53,214] {bash_operator.py:115} INFO - Running command: /Users/timsehn/liquidata/git/liquidata-etl-jobs/airflow_dags/word_net/import_from_source.pl 
[2019-11-18 11:04:53,221] {bash_operator.py:124} INFO - Output:
[2019-11-18 11:04:53,294] {bash_operator.py:128} INFO - Running: dolt clone Liquidata/word-net
[2019-11-18 11:04:53,404] {bash_operator.py:128} INFO - cloning https://doltremoteapi.dolthub.com/Liquidata/word-net
[2019-11-18 11:04:56,064] {bash_operator.py:128} INFO - 6,150 of 6,150 chunks complete. 0 chunks being downloaded currently.    
[2019-11-18 11:04:56,111] {bash_operator.py:128} INFO - 
[2019-11-18 11:04:56,111] {bash_operator.py:128} INFO - Running: mkdir data
[2019-11-18 11:04:56,114] {bash_operator.py:128} INFO - 
[2019-11-18 11:04:56,114] {bash_operator.py:128} INFO - Running: curl -L -O http://wordnetcode.princeton.edu/wn3.1.dict.tar.gz
[2019-11-18 11:04:56,121] {bash_operator.py:128} INFO -   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[2019-11-18 11:04:56,122] {bash_operator.py:128} INFO -                                  Dload  Upload   Total   Spent    Left  Speed
100   235  100   235    0     0   1694      0 --:--:-- --:--:-- --:--:--  1702
100 15.6M  100 15.6M    0     0  7801k      0  0:00:02  0:00:02 --:--:-- 13.1M
[2019-11-18 11:04:58,174] {bash_operator.py:128} INFO - 
[2019-11-18 11:04:58,213] {bash_operator.py:128} INFO - Current data matches downloaded data. Exiting...
[2019-11-18 11:04:58,214] {bash_operator.py:132} INFO - Command exited with return code 0
```