### PR TITLE
Fix MTA, FX rates, and IP to Country loaders

### DIFF
--- a/airflow_dags/fx_rates_example/dolt_load.py
+++ b/airflow_dags/fx_rates_example/dolt_load.py
@@ -33,7 +33,7 @@ def get_average_rates(df: pd.DataFrame) -> pd.DataFrame:
 
 def get_raw_table_loaders():
     raw_table_loaders = [get_df_table_writer('eur_fx_rates', get_data, ['currency', 'timestamp'])]
-    return get_dolt_loader(raw_table_loaders, True, 'Updated raw FX rates for date {}'.format(datetime.now()))
+    return [get_dolt_loader(raw_table_loaders, True, 'Updated raw FX rates for date {}'.format(datetime.now()))]
 
 
 def get_transformed_table_loaders():

--- a/airflow_dags/ip_to_country/dolt_load.py
+++ b/airflow_dags/ip_to_country/dolt_load.py
@@ -100,8 +100,11 @@ def get_df_builder(ip_to_country_dataset: IpToCountryDataset) -> Callable[[], pd
 
 
 def get_dolt_datasets():
+    table_writers = []
     for ip_to_country_dataset in ip_to_country_datasets:
         writer = get_df_table_writer(ip_to_country_dataset.name,
                                      get_df_builder(ip_to_country_dataset),
                                      ip_to_country_dataset.pk_cols)
-        yield get_dolt_loader([writer], True, 'Update IP to Country for date {}'.format(datetime.now()),)
+        table_writers.append(writer)
+
+    return [get_dolt_loader(table_writers, True, 'Update IP to Country for date {}'.format(datetime.now()))]

--- a/airflow_dags/mta/dolt_load.py
+++ b/airflow_dags/mta/dolt_load.py
@@ -46,13 +46,16 @@ def get_mta_url(dataset_id: str) -> str:
 
 
 def get_loaders():
+    table_writers = []
     for dataset in DATASETS:
         tramsformers = [] if dataset.pk_cols else [insert_unique_key]
         pk_cols = ['hash_id'] if not dataset.pk_cols else dataset.pk_cols
 
-        writer =  get_df_table_writer(dataset.table_name,
-                                      get_mta_data_as_df(get_mta_url(dataset.dataset_id)),
-                                      pk_cols,
-                                      transformers=tramsformers)
+        writer = get_df_table_writer(dataset.table_name,
+                                     get_mta_data_as_df(get_mta_url(dataset.dataset_id)),
+                                     pk_cols,
+                                     transformers=tramsformers)
 
-        yield get_dolt_loader([writer], True, 'Update MTA data for date {}'.format(datetime.now()))
+        table_writers.append(writer)
+
+    return [get_dolt_loader(table_writers, True, 'Update MTA data for date {}'.format(datetime.now()))]


### PR DESCRIPTION
Loader definitions always to return a list of loaders, use multiple table writers per loader instead of accidentally using the Wikipedia pattern of a single table writer per loader.