### PR TITLE
Create DAG to backfill currently available wikipedia dumps and fix dump path

### DIFF
--- a/airflow_dags/dag.py
+++ b/airflow_dags/dag.py
@@ -166,3 +166,17 @@ wikipedia_ngrams = PythonOperator(task_id='import-data',
                                                             WIKIPEDIA_NGRAMS_REPO),
                                   dag=wikipedia_ngrams_dag)
 
+# Backfill Wikipedia ngrams
+wikipedia_ngrams_backfill_dag = DAG(
+    'wikipedia-ngrams-backfill',
+    default_args=get_default_args_helper(datetime(2019, 12, 2)),
+    schedule_interval='@once',
+)
+
+dump_dates = ['20190820', '20190901', '20190920', '20191001', '20191020', '20191101', '20191120']
+for dump_date in dump_dates:
+    wikipedia_ngrams_backfill = PythonOperator(task_id='backfill-data',
+                                               python_callable=dolthub_loader,
+                                               op_kwargs=get_args_helper(partial(get_ngram_loaders, dump_date, dump_date),
+                                                                         WIKIPEDIA_NGRAMS_REPO),
+                                               dag=wikipedia_ngrams_backfill_dag)

--- a/airflow_dags/wikipedia/ngrams/dolt_load.py
+++ b/airflow_dags/wikipedia/ngrams/dolt_load.py
@@ -23,7 +23,7 @@ CURR_DIR = path.dirname(path.abspath(__file__))
 WIKIEXTRACTOR_PATH = path.join(Path(CURR_DIR).parent, 'wikiextractor/WikiExtractor.py')
 UNI_SHARD_LEN = int(3e6)
 BI_SHARD_LEN = 250000
-TRI_SHARD_LEN = 30000
+TRI_SHARD_LEN = 20000
 
 NGRAM_DICTS = {
     'unigram': defaultdict(lambda: defaultdict(int)),

--- a/airflow_dags/wikipedia/ngrams/dolt_load.py
+++ b/airflow_dags/wikipedia/ngrams/dolt_load.py
@@ -45,22 +45,21 @@ def fetch_data(dump_target: str):
     """
     bz2_file_name = 'enwiki-{}-pages-articles-multistream.xml.bz2'.format(dump_target)
     dump_url = 'https://dumps.wikimedia.your.org/enwiki/{}/{}'.format(dump_target, bz2_file_name)
-    dump_path = path.join(CURR_DIR, bz2_file_name)
 
     logging.info('Fetching Wikipedia XML dump from URL {}'.format(dump_url))
     r = requests.get(dump_url, stream=True)
-    with open(dump_path, 'wb') as f:
+    with open(bz2_file_name, 'wb') as f:
         for chunk in r.iter_content(chunk_size=1024):
             if chunk:
                 f.write(chunk)
     logging.info('Finished downloading XML dump')
-    return process_bz2(dump_path)
+    return process_bz2(bz2_file_name)
 
 
-def process_bz2(dump_path: str):
+def process_bz2(bz2_file_name: str):
     """
     Goes through dump and aggregates each article, passing it to add_ngrams
-    :param dump_path:
+    :param bz2_file_name:
     :return:
     """
     logging.info('Processing dump')
@@ -70,7 +69,7 @@ def process_bz2(dump_path: str):
     is_title = True
 
     with subprocess.Popen(
-        'bzcat {} | {} --no_templates -o - -'.format(dump_path, WIKIEXTRACTOR_PATH),
+        'bzcat {} | {} --no_templates -o - -'.format(bz2_file_name, WIKIEXTRACTOR_PATH),
         stdout=subprocess.PIPE,
         shell=True,
     ) as proc:


### PR DESCRIPTION
Gets ngrams for wikipedia dumps from 8-20-19 to now (before the latest dump which is 12-1-19)