### PR TITLE
Count lowered ngrams while processing dump instead of after

### DIFF
--- a/airflow_dags/dag.py
+++ b/airflow_dags/dag.py
@@ -178,7 +178,7 @@ wikipedia_ngrams_backfill_dag = DAG(
     schedule_interval='@once',
 )
 
-dump_dates = ['20190901', '20190920', '20191001', '20191020', '20191101', '20191120', '20191201']
+dump_dates = ['20190901', '20190920', '20191001', '20191020', '20191101', '20191120', '20191201', '20191220']
 tasks_list = []
 for i, dump_date in enumerate(dump_dates):
     tasks_list.append(PythonOperator(task_id='backfill-data-{}'.format(dump_date),


### PR DESCRIPTION
Changes load order from:

1. Go through dump
2. Write case-sensitive ngrams to csvs in shards
3. Merge sort case-sensitive ngram csvs into one big csv
4. Read big sorted case-sensitive csv and write case-insensitive ngrams to csvs in shards
5. Merge sort case-insensitive ngram csvs into one big csv
6. Load both to Dolt

To:

1. Go through dump
2. Write case-sensitive and case-insensitive ngrams to csvs in shards
3. Merge sort both case-sensitive and case-insensitive csvs into their own big csvs
4. Load both to Dolt

Also added `20191220` dump to backfill job (dump will be available by the time the job gets to it)