### PR TITLE
Updating mapping to map Orange, CA to California

### DIFF
--- a/airflow_dags/corona-virus/import-data.pl
+++ b/airflow_dags/corona-virus/import-data.pl
@@ -109,6 +109,7 @@ my $place_id_map = {
     'US' => {
 	'Illinois'    => 51,
 	'California'  => 52,
+	'Orange, CA'  => 52,
 	'Boston, MA'  => 63,
 	'Washington'  => 66,
 	'Arizona'     => 67,


### PR DESCRIPTION
This should fix production job as currently breaking with following error message:
```
[2020-02-08 03:02:52,206] {{bash_operator.py:128}} INFO - Could not determine place_id for country: 'US' and state: 'Orange, CA' at /usr/local/airflow/dags/liquidata-etl-jobs/airflow_dags/corona-virus/import-data.pl line 237.
[2020-02-08 03:02:52,207] {{bash_operator.py:128}} INFO - 
[2020-02-08 03:02:52,207] {{bash_operator.py:132}} INFO - Command exited with return code 255
[2020-02-08 03:02:52,227] {{taskinstance.py:1051}} ERROR - Bash command failed
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/airflow/models/taskinstance.py", line 926, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/usr/local/lib/python3.7/site-packages/airflow/operators/bash_operator.py", line 136, in execute
    raise AirflowException("Bash command failed")
airflow.exceptions.AirflowException: Bash command failed
```