### PR TITLE
/airflow_dags/dag.py: Change job frequency for expensive jobs

### DIFF
--- a/airflow_dags/dag.py
+++ b/airflow_dags/dag.py
@@ -237,7 +237,7 @@ raw_us_baby_names = BashOperator(
 corona_virus_dag = DAG(
     'corona_virus',
     default_args=get_default_args_helper(datetime(2020,2,5)),
-    schedule_interval=timedelta(days=7)
+    schedule_interval=timedelta(hours=12)
 )
 
 raw_corona_virus = BashOperator(
@@ -249,7 +249,7 @@ raw_corona_virus = BashOperator(
 corona_virus_details_dag = DAG(
     'corona_virus_details',
     default_args=get_default_args_helper(datetime(2020,3,3)),
-    schedule_interval=timedelta(days=7)
+    schedule_interval=timedelta(days=1)
 )
 
 singapore_details = BashOperator(

--- a/airflow_dags/dag.py
+++ b/airflow_dags/dag.py
@@ -80,7 +80,7 @@ raw_word_net = BashOperator(
 github_repos_dag = DAG(
     'github_repos',
     default_args=get_default_args_helper(datetime(2020, 3, 5)),
-    schedule_interval=timedelta(days=1)
+    schedule_interval=timedelta(days=7)
 )
 
 raw_github_repos = BashOperator(
@@ -237,7 +237,7 @@ raw_us_baby_names = BashOperator(
 corona_virus_dag = DAG(
     'corona_virus',
     default_args=get_default_args_helper(datetime(2020,2,5)),
-    schedule_interval=timedelta(hours=12)
+    schedule_interval=timedelta(days=7)
 )
 
 raw_corona_virus = BashOperator(
@@ -249,7 +249,7 @@ raw_corona_virus = BashOperator(
 corona_virus_details_dag = DAG(
     'corona_virus_details',
     default_args=get_default_args_helper(datetime(2020,3,3)),
-    schedule_interval=timedelta(hours=1)
+    schedule_interval=timedelta(days=7)
 )
 
 singapore_details = BashOperator(


### PR DESCRIPTION
Corona Virus takes 2 hours to run we want to change it from running every 12 hours to running once a week.
Corona Virus Details HK takes around 7.5 hours to run and runs every hour, we want to change it to once a week.
Github Repos takes 3 hours to run, and runs once a day, we want to change it to once a week.